### PR TITLE
Id 2247 add delete node endpoint

### DIFF
--- a/models/models.h
+++ b/models/models.h
@@ -46,13 +46,16 @@ struct Connection {
 using EdgeLabelMap = std::map<std::string, int>;
 
 using TagHierarchyGraph = boost::adjacency_list<
-        boost::listS, boost::vecS, boost::bidirectionalS,
+        boost::listS, boost::listS, boost::bidirectionalS,
         Modelhierarchy, Connection>;
 
 using TagHierarchyT = boost::labeled_graph<TagHierarchyGraph, std::string>;
 
 using VertexT = boost::graph_traits<TagHierarchyGraph>::vertex_descriptor;
+using VertexIter = boost::graph_traits<TagHierarchyGraph>::vertex_iterator;
 using EdgeT = boost::graph_traits<TagHierarchyGraph>::edge_descriptor;
+
+using VertexDescMap = std::map<VertexT, size_t>;
 
 namespace boost {
 namespace serialization {

--- a/tag_hierarchy/CMakeLists.txt
+++ b/tag_hierarchy/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(tag_hierarchy
 set(UNIT_TEST_FILES
     unittests/test_tag_hierarchy.cpp
     unittests/test_delete_command.cpp
+    unittests/test_load_save.cpp
 )
 add_executable(tag_hierarchy_test
         ${UNIT_TEST_FILES})
@@ -59,6 +60,7 @@ add_executable(tag_hierarchy_test
 target_include_directories(tag_hierarchy_test
     PRIVATE ${CMAKE_SOURCE_DIR}
 )
+target_compile_definitions(tag_hierarchy_test PRIVATE BOOST_TEST_DYN_LINK)
 
 target_link_libraries(tag_hierarchy_test
     PRIVATE tag_hierarchy

--- a/tag_hierarchy/CMakeLists.txt
+++ b/tag_hierarchy/CMakeLists.txt
@@ -4,6 +4,8 @@
 add_library(tag_hierarchy_commands OBJECT
         commands/command.cpp
         commands/command.h
+        commands/delete.cpp
+        commands/delete.h
         commands/populategraph.cpp
         commands/populategraph.h
         commands/nodes.cpp
@@ -47,9 +49,12 @@ target_link_libraries(tag_hierarchy
     PUBLIC pybind11
     PUBLIC libzmq)
 
-add_executable(tag_hierarchy_test
+set(UNIT_TEST_FILES
     unittests/test_tag_hierarchy.cpp
+    unittests/test_delete_command.cpp
 )
+add_executable(tag_hierarchy_test
+        ${UNIT_TEST_FILES})
 
 target_include_directories(tag_hierarchy_test
     PRIVATE ${CMAKE_SOURCE_DIR}
@@ -64,13 +69,18 @@ target_link_libraries(tag_hierarchy_test
     PUBLIC ${PYTHON_LIBRARIES}
 )
 
-file(READ "unittests/test_tag_hierarchy.cpp" SOURCE_FILE_CONTENTS)
-string(REGEX MATCHALL "BOOST_AUTO_TEST_CASE\\( *([A-Za-z_0-9]+) *\\)" 
+foreach(UNIT_TEST_FILE ${UNIT_TEST_FILES})
+file(READ "${UNIT_TEST_FILE}" SOURCE_FILE_CONTENTS)
+string(REGEX MATCHALL "BOOST_.+_TEST_SUITE\\( *([A-Za-z_0-9]+).*\\)"
+        TEST_SUITE_NAME ${SOURCE_FILE_CONTENTS})
+set(TEST_SUITE_NAME ${CMAKE_MATCH_1})
+string(REGEX MATCHALL "BOOST_AUTO_TEST_CASE\\( *([A-Za-z_0-9]+) *\\)"
        FOUND_TESTS ${SOURCE_FILE_CONTENTS})
 foreach(HIT ${FOUND_TESTS})
     string(REGEX REPLACE ".*\\( *([A-Za-z_0-9]+) *\\).*" "\\1" TEST_NAME ${HIT})
    
     add_test(NAME "tag_hierarchy_test.${TEST_NAME}" 
             COMMAND tag_hierarchy_test
-            --run_test=NodesTest/${TEST_NAME} --catch_system_error=yes)
+            --run_test=${TEST_SUITE_NAME}/${TEST_NAME} --catch_system_error=yes)
+endforeach()
 endforeach()

--- a/tag_hierarchy/commands/delete.cpp
+++ b/tag_hierarchy/commands/delete.cpp
@@ -1,0 +1,43 @@
+#include "tag_hierarchy/commands/delete.h"
+
+namespace {
+    namespace local {
+        /* Recursively delete all children and all connecting edges from \param vertex */
+        std::string
+        DeleteVertex(TagHierarchyGraph& graph, VertexT vertex) {
+            auto [vi, vi_end] = boost::adjacent_vertices(vertex, graph);
+            for (auto iter = vi; vi != vi_end; vi = iter) {
+                ++iter;
+                DeleteVertex(graph, *vi);
+            }
+            boost::clear_vertex(vertex, graph);
+            boost::remove_vertex(vertex, graph);
+            return "Success";
+        }
+    }
+}
+
+// Register command with TagHierarchy
+Delete del(std::string("delete"));
+
+Delete::Delete(std::string name) : Command(name) {}
+
+std::vector<NodeType>
+Delete::ProcessRequest(std::vector<NodeType> &nodes)
+{
+    auto& graph = GetGraph();
+    auto& vertices = GetVertices();
+    auto command_map = nodes.at(0);
+    // Check if graph has been initialized
+    auto nodes_to_delete = boost::get<std::vector<std::string>>(command_map.at("nodes"));
+    auto status = NodeType();
+    for (auto const& node : nodes_to_delete) {
+        if (!vertices.count(node)) {
+            status[node] = "Not found";
+            continue;
+        }
+        auto vertex = vertices[node];
+        status[node] = local::DeleteVertex(graph, vertex);
+    }
+    return {status};
+}

--- a/tag_hierarchy/commands/delete.h
+++ b/tag_hierarchy/commands/delete.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "tag_hierarchy/tag_hierarchy.h"
+#include "tag_hierarchy/commands/command.h"
+
+class Delete : Command {
+public:
+    explicit Delete(std::string name);
+private:
+    std::vector<NodeType> ProcessRequest(std::vector<NodeType>& request) override;
+};

--- a/tag_hierarchy/commands/filteroptions.cpp
+++ b/tag_hierarchy/commands/filteroptions.cpp
@@ -21,16 +21,17 @@ FilterOptions::ProcessRequest(std::vector<NodeType> &nodes)
         return {{{std::string("error"), std::string("empty")}}};
     }
 
+    auto index_map = VertexDescMap();
+    boost::associative_property_map<VertexDescMap> colormap(index_map);
     const auto filter_type = boost::get<std::string>(command_map.at("type"));
     auto valid_ids = std::set<std::string>();
-    std::vector<boost::default_color_type> colormap(num_vertices(graph_));
     if (filter_type == "modelowner") {
         const auto visitor = ModelOwnerFilterOptionsVisitor(valid_ids);
-        boost::depth_first_visit(graph_, root_, visitor, colormap.data());
+        boost::depth_first_visit(graph_, root_, visitor, colormap);
     }
     else if (filter_type == "modelclass") {
         const auto visitor = ModelClassFilterOptionsVisitor(valid_ids);
-        boost::depth_first_visit(graph_, root_, visitor, colormap.data());
+        boost::depth_first_visit(graph_, root_, visitor, colormap);
     }
     else {
         return {{{std::string("error"), std::string("unknown filter type")}}};

--- a/tag_hierarchy/commands/nodes.cpp
+++ b/tag_hierarchy/commands/nodes.cpp
@@ -114,8 +114,9 @@ Nodes::ProcessRequest(std::vector<NodeType> &nodes)
         parent_vertex = vertices_[parent_id];
     }
 
-    std::vector<boost::default_color_type> colormap(num_vertices(graph_));
-    boost::depth_first_visit(graph_, parent_vertex, dfs_visitor, colormap.data(), termfunc);
+    auto index_map = VertexDescMap();
+    boost::associative_property_map<VertexDescMap> colormap(index_map);
+    boost::depth_first_visit(graph_, parent_vertex, dfs_visitor, colormap, termfunc);
 
     auto ei = TagHierarchyGraph::adjacency_iterator();
     auto ei_end = TagHierarchyGraph::adjacency_iterator();

--- a/tag_hierarchy/tag_hierarchy.cpp
+++ b/tag_hierarchy/tag_hierarchy.cpp
@@ -146,12 +146,24 @@ public:
     }
 
     template<typename Archive>
-    void serialize(Archive& ar, const unsigned int version) {
+    void save(Archive& ar, const unsigned int version) const {
         ar & graph_;
-        ar & vertices_;
-        ar & root_;
         ar & edge_labels_;
     }
+
+    template<typename Archive>
+    void load(Archive& ar, const unsigned int version) {
+        ar & graph_;
+        ar & edge_labels_;
+        auto [start, end] = boost::vertices(graph_);
+        for (auto iter = start; iter != end; ++iter) {
+            if (graph_[*iter].id == "root") {
+                root_ = *iter;
+            }
+            vertices_[graph_[*iter].id] = *iter;
+        }
+    }
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
 };
 
 

--- a/tag_hierarchy/unittests/fixture.h
+++ b/tag_hierarchy/unittests/fixture.h
@@ -1,0 +1,20 @@
+#include "models/models.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include "tag_hierarchy/tag_hierarchy.h"
+
+struct Fixture {
+    Fixture() {
+        BOOST_TEST_MESSAGE( "Constructing test fixture" );
+        auto modelhierarchy = std::vector<NodeType>(
+#include "hierarchy_dump.cpp"
+        );
+        TagHierarchy::Handle(modelhierarchy);
+    }
+
+    ~Fixture() {
+        BOOST_TEST_MESSAGE( "teardown fixture" );
+    }
+};
+

--- a/tag_hierarchy/unittests/test_delete_command.cpp
+++ b/tag_hierarchy/unittests/test_delete_command.cpp
@@ -1,0 +1,27 @@
+#include "models/models.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include "tag_hierarchy/tag_hierarchy.h"
+#include "tag_hierarchy/unittests/fixture.h"
+
+BOOST_FIXTURE_TEST_SUITE( DeleteCommandTest, Fixture );
+    BOOST_AUTO_TEST_CASE( test_delete_command )
+    {
+        auto query = std::vector<NodeType>(
+                {{{std::string("command"), std::string("delete")},
+                         {std::string("nodes"), std::vector<std::string>({"33382bc4-249b-a646-ef2b-14033605bae0"})}}}
+        );
+        auto response = TagHierarchy::Handle(query);
+        BOOST_TEST(boost::get<std::string>(response[0].at("33382bc4-249b-a646-ef2b-14033605bae0")) == "Success");
+
+        auto query2 = std::vector<NodeType>(
+                {{{std::string("command"), std::string("nodes")},
+                         {std::string("parentId"), pybind11::none()}}}
+        );
+        auto response2 = TagHierarchy::Handle(query2);
+        BOOST_TEST(boost::get<std::string>(response2[0].at("name")) == "Level1-1");
+        BOOST_TEST(response2.size() == 1);
+    }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tag_hierarchy/unittests/test_load_save.cpp
+++ b/tag_hierarchy/unittests/test_load_save.cpp
@@ -1,0 +1,44 @@
+#include "models/models.h"
+
+#include "tag_hierarchy/tag_hierarchy.h"
+#include "tag_hierarchy/unittests/fixture.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE( LoadSaveCommandsTest, Fixture );
+    BOOST_AUTO_TEST_CASE( test_load_save_command )
+    {
+        // Store and restore the graph using the commands
+        auto store_command = std::vector<NodeType>(
+                {{{std::string("command"), std::string("store")}}}
+        );
+        auto store_response = TagHierarchy::Handle(store_command);
+        const auto& serialized_graph = boost::get<std::string>(store_response[0]["serialized_graph"]);
+        auto restore_command = std::vector<NodeType>(
+                {{{std::string("command"), std::string("restore")},
+                         {std::string("serialized_hierarchy"), serialized_graph}}}
+        );
+        auto restore_response = TagHierarchy::Handle(restore_command);
+
+        auto query2 = std::vector<NodeType>(
+                {{{std::string("command"), std::string("nodes")},
+                         {std::string("parentId"), pybind11::none()}}}
+        );
+        auto response2 = TagHierarchy::Handle(query2);
+        BOOST_TEST(boost::get<std::string>(response2[0].at("name")) == "Level1-1");
+        BOOST_TEST(response2.size() == 2);
+
+        // Verify that vertices are still correctly looked up by ID
+        const auto parent_id = std::string("0979534e-9dc1-bf0e-208a-d508862888fe");
+        auto l3query = std::vector<NodeType>(
+                {{{std::string("command"), std::string("nodes")},
+                         {std::string("parentId"), parent_id}}}
+        );
+        auto l3response = TagHierarchy::Handle(l3query);
+        BOOST_TEST(boost::get<std::string>(l3response[1].at("name")) == "Level1-2->Level2-1->Level3-2");
+        BOOST_TEST(boost::get<int>(l3response[0].at("levelno")) == 3);
+        BOOST_TEST(boost::get<std::string>(l3response[1].at("parent_id")) == parent_id);
+        std::cout << boost::get<std::string>(l3response[1].at("id"));
+    }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tag_hierarchy/unittests/test_tag_hierarchy.cpp
+++ b/tag_hierarchy/unittests/test_tag_hierarchy.cpp
@@ -1,25 +1,12 @@
 #define BOOST_TEST_MODULE tag_hierarchy
-#define BOOST_TEST_DYN_LINK
 
 #include "models/models.h"
 
 #include <boost/test/unit_test.hpp>
 
 #include "tag_hierarchy/tag_hierarchy.h"
+#include "tag_hierarchy/unittests/fixture.h"
 
-struct Fixture {
-  Fixture() {
-     BOOST_TEST_MESSAGE( "Constructing test fixture" );
-     auto modelhierarchy = std::vector<NodeType>(
-     #include "hierarchy_dump.cpp"
-     );
-     TagHierarchy::Handle(modelhierarchy);
-  }
-
-  ~Fixture() {
-      BOOST_TEST_MESSAGE( "teardown fixture" );
-  }
-};
 
 BOOST_FIXTURE_TEST_SUITE( NodesTest, Fixture );
 BOOST_AUTO_TEST_CASE( test_nodes )

--- a/tag_hierarchy/unittests/test_tag_hierarchy.cpp
+++ b/tag_hierarchy/unittests/test_tag_hierarchy.cpp
@@ -1,8 +1,9 @@
-#define BOOST_TEST_MODULE tag_hierarchy
+#define BOOST_TEST_MODULE tag_hierarchy_test
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
 
 #include "models/models.h"
-
-#include <boost/test/unit_test.hpp>
 
 #include "tag_hierarchy/tag_hierarchy.h"
 #include "tag_hierarchy/unittests/fixture.h"


### PR DESCRIPTION
Adding an endpoint for deleting nodes. Had to change the underlying data structure for the graph, because storing vertices in a vector makes it extremely slow to delete nodes in the graph because every time a node is deleted the vertices get re-indexed. This changes the vertices to be stored in a linked list, which makes re-indexing unneccessary when deleting nodes. Adding nodes becomes a bit slower, but not dramatically.